### PR TITLE
fix php warnings for TYPO3 v11 and PHP 8.1

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@
 call_user_func(function () {
     $cachingConfigurations = &$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'];
     if (is_array($cachingConfigurations)) {
-        if (!is_array($cachingConfigurations['pretty_preview_content'])) {
+        if (!array_key_exists('pretty_preview_content', $cachingConfigurations)) {
             $cachingConfigurations['pretty_preview_content']  = [
                 'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
                 'backend' => \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class,

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -12,7 +12,7 @@ call_user_func(function () {
         ];
 
         // Fallback to Classic Hook if "fluidBasedPageModule" is deactivated
-        if (!$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidBasedPageModule']) {            
+        if (!array_key_exists('fluidBasedPageModule', $GLOBALS['TYPO3_CONF_VARS']['SYS']['features'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['tt_content_drawItem']['jar_pretty_preview'] = \Jar\PrettyPreview\Hooks\PreviewRendererHook::class;
         }
     }


### PR DESCRIPTION
fixes #1